### PR TITLE
TravisCI docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,15 @@
-language: ruby
+language: generic
 cache:
-  - bundler
-  - pip
-rvm:
-  - 2.3
-jdk:
-  - oraclejdk8
-before_script:
-  - pip install --user html5validator
+  - docker
+services:
+  - docker
 script: ./script/cibuild
 branches:
   only:
   - master
-env:
-  global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+#env:
+#  global:
+#  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 deploy:
   provider: script
   script: ./script/deploy

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source 'https://rubygems.org'
 gem 'jekyll'
 gem 'html-proofer'
 
-#gem 'jekyll-tagging'
-#gem 'jekyll-paginate'
 group :jekyll_plugins do
     gem "jekyll-last-modified-at"
 end
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
-require 'html-proofer'
-
 task :test do
   sh "bundle exec jekyll build"
   options = { :assume_extension => true, :url_ignore => [ /^https?.+/ ]}
-  HTMLProofer.check_directory("./_site", options).run
+  begin
+    require 'html-proofer'
+    HTMLProofer.check_directory("./_site", options).run
+  end
 end

--- a/script/cibuild
+++ b/script/cibuild
@@ -4,9 +4,13 @@ set -e # halt script on error
 mkdir _site
 chmod a+w Gemfile.lock _site
 
-bundle exec jekyll build
-bundle exec htmlproofer ./_site --disable-external
-$HOME/.local/bin/html5validator --root ./_site
+# Install dependencies
+docker-compose run site bundle install
+
+# Build and test _site
+docker-compose run site rake test
+
+docker run -v $(pwd)/_site:/app stratdat/html5validator
 
 #node --version
 #./node_modules/a11y/cli.js --help

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
-# bundle install
+mkdir _site
+chmod a+w Gemfile.lock _site
 
 bundle exec jekyll build
 bundle exec htmlproofer ./_site --disable-external


### PR DESCRIPTION
Use docker to run all CI steps. This means we can run exactly the same in dev as CI.